### PR TITLE
add more env vars for the 4 roles on the USDC-e token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 RPC_URL=https://eth-goerli.g.alchemy.com/v2/YOUR_API_KEY
 ETHERSCAN_API_KEY=VV4REST_OF_YOUR_API_KEY
-# NOTE: this is the admin for the L2 USDC-E
-ADDRESS_ADMIN=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+# NOTE: this is the master minter for the L2 USDC-E
+ADDRESS_MASTER_MINTER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+# NOTE: this is the address able to pause calls for the L2 USDC-E
+ADDRESS_PAUSER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+# NOTE: this is the address able to prevent other addreses from calling the L2 USDC-E
+ADDRESS_BLACKLISTER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+# NOTE: this is the owner who is able to update the master minter, pauser, and blacklister on the L2 USDC-E
+ADDRESS_OWNER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 # NOTE: this is the L2 USDC-E deployed by us
 ADDRESS_USDC=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
 # NOTE: these are the USDC-LXLY contracts

--- a/script/DeployInit.s.sol
+++ b/script/DeployInit.s.sol
@@ -30,7 +30,11 @@ contract DeployInitUSDC is Script {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
 
-        address admin = vm.envAddress("ADDRESS_ADMIN");
+        // setup the addresses for the various roles
+        address masterMinter = vm.envAddress("ADDRESS_MASTER_MINTER");
+        address pauser = vm.envAddress("ADDRESS_PAUSER");
+        address blacklister = vm.envAddress("ADDRESS_BLACKLISTER");
+        address owner = vm.envAddress("ADDRESS_OWNER");
 
         FiatTokenV2_1 usdc = new FiatTokenV2_1();
         usdc.initialize(
@@ -38,13 +42,15 @@ contract DeployInitUSDC is Script {
             "USDC",
             "USD",
             6,
-            admin, // master minter
-            admin, // pauser
-            admin, // blacklister
-            admin // owner
+            masterMinter,
+            pauser,
+            blacklister,
+            owner
         );
         usdc.initializeV2("USD Coin");
-        usdc.initializeV2_1(admin);
+        // the lostAndFound address here doesn't matter, because there will not be
+        // a nonzero balance on the USDC-e contract (since we just deployed it)
+        usdc.initializeV2_1(address(0));
 
         vm.stopBroadcast();
     }


### PR DESCRIPTION
Prior to this commit, we used a single admin address for all 4 of the distinct roles on the USDC-e (master minter, pauser, blacklister, owner). Now, we have env vars for all 4 of those roles